### PR TITLE
Add Maglev support

### DIFF
--- a/lib/redcard.rb
+++ b/lib/redcard.rb
@@ -28,8 +28,10 @@ class RedCard
       # TODO
     when "jruby"
       Object.const_get :JRUBY_VERSION
-    # when "maglev"
-      # TODO
+    when "maglev"
+      if defined?(::Maglev)
+        Object.const_get(:MAGLEV_VERSION)
+      end
     when "rbx"
       if defined?(::Rubinius)
         Object.const_get(:Rubinius).const_get(:VERSION)

--- a/lib/redcard/maglev/1.0.rb
+++ b/lib/redcard/maglev/1.0.rb
@@ -1,0 +1,3 @@
+require 'redcard'
+
+RedCard.verify :maglev => "1.0"

--- a/lib/redcard/maglev/1.0.rb
+++ b/lib/redcard/maglev/1.0.rb
@@ -1,3 +1,3 @@
 require 'redcard'
 
-RedCard.verify :maglev => "1.0"
+RedCard.verify(("1.8".."1.8.7"), :maglev => "1.0")

--- a/lib/redcard/maglev/1.1.rb
+++ b/lib/redcard/maglev/1.1.rb
@@ -1,3 +1,3 @@
 require 'redcard'
 
-RedCard.verify :maglev => "1.1"
+RedCard.verify(("1.8".."1.8.7"), :maglev => "1.1")

--- a/lib/redcard/maglev/1.1.rb
+++ b/lib/redcard/maglev/1.1.rb
@@ -1,0 +1,3 @@
+require 'redcard'
+
+RedCard.verify :maglev => "1.1"

--- a/lib/redcard/maglev/2.0.rb
+++ b/lib/redcard/maglev/2.0.rb
@@ -1,0 +1,3 @@
+require 'redcard'
+
+RedCard.verify :maglev => "2.0"

--- a/lib/redcard/maglev/2.0.rb
+++ b/lib/redcard/maglev/2.0.rb
@@ -1,3 +1,3 @@
 require 'redcard'
 
-RedCard.verify :maglev => "2.0"
+RedCard.verify "1.9.3", :maglev => "2.0"

--- a/spec/maglev/1.0_spec.rb
+++ b/spec/maglev/1.0_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe "MagLev version requirement" do
+  before do
+    redcard_save_state
+    redcard_unload "redcard/maglev/1.0"
+  end
+
+  after do
+    redcard_restore_state
+  end
+
+  it "succeeds if RUBY_ENGINE is 'maglev' and MAGLEV_VERSION is greater than or equal to 1.0" do
+    redcard_engine "maglev"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/1.0' }.not_to raise_error
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'topaz'" do
+    redcard_engine "topaz"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/1.0' }.to raise_error(RedCard::InvalidRubyError)
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'rbx'" do
+    redcard_engine "rbx"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/1.0' }.to raise_error(RedCard::InvalidRubyError)
+  end
+
+end

--- a/spec/maglev/1.0_spec.rb
+++ b/spec/maglev/1.0_spec.rb
@@ -12,20 +12,52 @@ describe "MagLev version requirement" do
 
   it "succeeds if RUBY_ENGINE is 'maglev' and MAGLEV_VERSION is greater than or equal to 1.0" do
     redcard_engine "maglev"
+    redcard_version "1.8.7"
     redcard_engine_version "1.0.0"
     expect { require 'redcard/maglev/1.0' }.not_to raise_error
   end
 
   it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'topaz'" do
     redcard_engine "topaz"
+    redcard_version "1.8.7"
     redcard_engine_version "1.0.0"
     expect { require 'redcard/maglev/1.0' }.to raise_error(RedCard::InvalidRubyError)
   end
 
   it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'rbx'" do
     redcard_engine "rbx"
+    redcard_version "1.8.7"
     redcard_engine_version "1.0.0"
     expect { require 'redcard/maglev/1.0' }.to raise_error(RedCard::InvalidRubyError)
   end
+
+end
+
+describe "MagLev's Ruby-version dependency" do
+
+  before do
+    redcard_save_state
+    redcard_unload "redcard/1.8"
+    redcard_unload "redcard/1.9"
+    redcard_unload "redcard/maglev/1.0"
+  end
+
+  after do
+    redcard_restore_state
+  end
+
+  it "succeeds if MAGLEV_VERSION is 1.0 and RUBY_VERSION is not greater than 1.8" do
+    redcard_engine "maglev"
+    redcard_version "1.8.7"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/1.0' }.not_to raise_error
+ end
+
+  it "raises an InvalidRubyVersionError if MAGLEV_VERSION is 1.0 and RUBY_VERSION is greater than 1.8" do
+    redcard_engine "maglev"
+    redcard_version "1.9.3"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/1.0' }.to raise_error(RedCard::InvalidRubyVersionError)
+ end
 
 end

--- a/spec/maglev/1.1_spec.rb
+++ b/spec/maglev/1.1_spec.rb
@@ -12,25 +12,58 @@ describe "MagLev version requirement" do
 
   it "succeeds if RUBY_ENGINE is 'maglev' and MAGLEV_VERSION is greater than or equal to 1.1" do
     redcard_engine "maglev"
+    redcard_version "1.8.7"
     redcard_engine_version "1.1.0"
     expect { require 'redcard/maglev/1.1' }.not_to raise_error
   end
 
   it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'topaz'" do
     redcard_engine "topaz"
+    redcard_version "1.8.7"
     redcard_engine_version "1.1.0"
     expect { require 'redcard/maglev/1.1' }.to raise_error(RedCard::InvalidRubyError)
   end
 
   it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'rbx'" do
     redcard_engine "rbx"
-    redcard_engine_version "1.0.0"
+    redcard_version "1.8.7"
+    redcard_engine_version "1.1.0"
     expect { require 'redcard/maglev/1.1' }.to raise_error(RedCard::InvalidRubyError)
   end
 
-  it "raises an InvalidEngineVersionError if MAGLEV_VERSION is less than 1.0" do
+  it "raises an InvalidEngineVersionError if MAGLEV_VERSION is less than 1.1" do
     redcard_engine "maglev"
+    redcard_version "1.8.7"
     redcard_engine_version "1.0.0"
     expect { require 'redcard/maglev/1.1' }.to raise_error(RedCard::InvalidRubyError)
   end
+end
+
+describe "MagLev's Ruby-version dependency" do
+
+  before do
+    redcard_save_state
+    redcard_unload "redcard/1.8"
+    redcard_unload "redcard/1.9"
+    redcard_unload "redcard/maglev/1.1"
+  end
+
+  after do
+    redcard_restore_state
+  end
+
+  it "succeeds if MAGLEV_VERSION is 1.1 and RUBY_VERSION is not greater than 1.8" do
+    redcard_engine "maglev"
+    redcard_version "1.8.7"
+    redcard_engine_version "1.1.0"
+    expect { require 'redcard/maglev/1.1' }.not_to raise_error
+ end
+
+  it "raises an InvalidRubyVersionError if MAGLEV_VERSION is 1.1 and RUBY_VERSION is greater than 1.8" do
+    redcard_engine "maglev"
+    redcard_version "1.9.3"
+    redcard_engine_version "1.1.0"
+    expect { require 'redcard/maglev/1.1' }.to raise_error(RedCard::InvalidRubyVersionError)
+ end
+
 end

--- a/spec/maglev/1.1_spec.rb
+++ b/spec/maglev/1.1_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "MagLev version requirement" do
+  before do
+    redcard_save_state
+    redcard_unload "redcard/maglev/1.1"
+  end
+
+  after do
+    redcard_restore_state
+  end
+
+  it "succeeds if RUBY_ENGINE is 'maglev' and MAGLEV_VERSION is greater than or equal to 1.1" do
+    redcard_engine "maglev"
+    redcard_engine_version "1.1.0"
+    expect { require 'redcard/maglev/1.1' }.not_to raise_error
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'topaz'" do
+    redcard_engine "topaz"
+    redcard_engine_version "1.1.0"
+    expect { require 'redcard/maglev/1.1' }.to raise_error(RedCard::InvalidRubyError)
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'rbx'" do
+    redcard_engine "rbx"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/1.1' }.to raise_error(RedCard::InvalidRubyError)
+  end
+
+  it "raises an InvalidEngineVersionError if MAGLEV_VERSION is less than 1.0" do
+    redcard_engine "maglev"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/1.1' }.to raise_error(RedCard::InvalidRubyError)
+  end
+end

--- a/spec/maglev/2.0_spec.rb
+++ b/spec/maglev/2.0_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "MagLev version requirement" do
+  before do
+    redcard_save_state
+    redcard_unload "redcard/maglev/2.0"
+  end
+
+  after do
+    redcard_restore_state
+  end
+
+  it "succeeds if RUBY_ENGINE is 'maglev' and MAGLEV_VERSION is greater than or equal to 2.0" do
+    redcard_engine "maglev"
+    redcard_engine_version "2.0.0"
+    expect { require 'redcard/maglev/2.0' }.not_to raise_error
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'topaz'" do
+    redcard_engine "topaz"
+    redcard_engine_version "2.0.0"
+    expect { require 'redcard/maglev/2.0' }.to raise_error(RedCard::InvalidRubyError)
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'rbx'" do
+    redcard_engine "rbx"
+    redcard_engine_version "2.0.0"
+    expect { require 'redcard/maglev/2.0' }.to raise_error(RedCard::InvalidRubyError)
+  end
+
+  it "raises an InvalidEngineVersionError if MAGLEV_VERSION is less than 2.0" do
+    redcard_engine "maglev"
+    redcard_engine_version "1.0.0"
+    expect { require 'redcard/maglev/2.0' }.to raise_error(RedCard::InvalidRubyError)
+  end
+end

--- a/spec/maglev/2.0_spec.rb
+++ b/spec/maglev/2.0_spec.rb
@@ -12,25 +12,58 @@ describe "MagLev version requirement" do
 
   it "succeeds if RUBY_ENGINE is 'maglev' and MAGLEV_VERSION is greater than or equal to 2.0" do
     redcard_engine "maglev"
+    redcard_version "1.9.3"
     redcard_engine_version "2.0.0"
     expect { require 'redcard/maglev/2.0' }.not_to raise_error
   end
 
   it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'topaz'" do
     redcard_engine "topaz"
+    redcard_version "1.9.3"
     redcard_engine_version "2.0.0"
     expect { require 'redcard/maglev/2.0' }.to raise_error(RedCard::InvalidRubyError)
   end
 
   it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'rbx'" do
     redcard_engine "rbx"
+    redcard_version "1.9.3"
     redcard_engine_version "2.0.0"
     expect { require 'redcard/maglev/2.0' }.to raise_error(RedCard::InvalidRubyError)
   end
 
   it "raises an InvalidEngineVersionError if MAGLEV_VERSION is less than 2.0" do
     redcard_engine "maglev"
+    redcard_version "1.9.3"
     redcard_engine_version "1.0.0"
     expect { require 'redcard/maglev/2.0' }.to raise_error(RedCard::InvalidRubyError)
   end
+end
+
+describe "MagLev's Ruby-version dependency" do
+
+  before do
+    redcard_save_state
+    redcard_unload "redcard/1.8"
+    redcard_unload "redcard/1.9"
+    redcard_unload "redcard/maglev/2.0"
+  end
+
+  after do
+    redcard_restore_state
+  end
+
+  it "succeeds if MAGLEV_VERSION is 2.0 and RUBY_VERSION is not less than 1.9" do
+    redcard_engine "maglev"
+    redcard_version "1.9.3"
+    redcard_engine_version "2.0.0"
+    expect { require 'redcard/maglev/2.0' }.not_to raise_error
+ end
+
+  it "raises an InvalidRubyVersionError if MAGLEV_VERSION is 2.0 and RUBY_VERSION less than 1.9" do
+    redcard_engine "maglev"
+    redcard_version "1.8.7"
+    redcard_engine_version "2.0.0"
+    expect { require 'redcard/maglev/2.0' }.to raise_error(RedCard::InvalidRubyVersionError)
+ end
+
 end

--- a/spec/maglev_spec.rb
+++ b/spec/maglev_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe "Ruby engine requirement" do
+  before do
+    redcard_save_state
+    redcard_unload "redcard/maglev"
+  end
+
+  after do
+    redcard_restore_state
+  end
+
+  it "succeeds if RUBY_ENGINE is 'maglev'" do
+    redcard_engine "maglev"
+    expect { require 'redcard/maglev' }.not_to raise_error
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'topaz'" do
+    redcard_engine "topaz"
+    expect { require 'redcard/maglev' }.to raise_error(RedCard::InvalidRubyEngineError)
+  end
+
+  it "raises an InvalidRubyEngineError if RUBY_ENGINE is 'rbx'" do
+    redcard_engine "rbx"
+    expect { require 'redcard/maglev' }.to raise_error(RedCard::InvalidRubyEngineError)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,8 +48,8 @@ class RedCard
         # TODO
       when "jruby"
         Object.const_set :JRUBY_VERSION, version
-      # when "maglev"
-        # TODO
+      when "maglev"
+        Object.const_set :MAGLEV_VERSION, version
       when "rbx"
         unless defined?(::Rubinius)
           Object.const_set :Rubinius, Module.new


### PR DESCRIPTION
This adds support for checking for MagLev via redcard.
This also honor the fact that MagLev 1.x is only for Ruby <= 1.8.7
and MagLev 2.0.x is only for Ruby >= 1.9
